### PR TITLE
fix(events): fixed create_event markdown parsing error

### DIFF
--- a/src/commands/events.ts
+++ b/src/commands/events.ts
@@ -305,17 +305,17 @@ export const handleEventWizard = async (ctx: Context) => {
       await ctx.reply(
         '**Step 3/6:** What is the event format?\n\n' +
         'Please choose one:\n' +
-        '• **talk** - Single speaker presentation\n' +
-        '• **workshop** - Interactive learning session\n' +
-        '• **moderated_discussion** - Facilitated discussion\n' +
-        '• **conference** - Large-scale conference\n' +
-        '• **hangout** - Casual social gathering\n' +
-        '• **meeting** - Formal meeting\n' +
-        '• **external_speaker** - Event with external speaker\n' +
-        '• **newsletter** - Newsletter content creation\n' +
-        '• **social_media_campaign** - Social media campaign\n' +
-        '• **coding_project** - Open-source or internal coding project\n' +
-        '• **others** - Other event type\n\n' +
+        '• `talk` - Single speaker presentation\n' +
+        '• `workshop` - Interactive learning session\n' +
+        '• `moderated_discussion` - Facilitated discussion\n' +
+        '• `conference` - Large-scale conference\n' +
+        '• `hangout` - Casual social gathering\n' +
+        '• `meeting` - Formal meeting\n' +
+        '• `external_speaker` - Event with external speaker\n' +
+        '• `newsletter` - Newsletter content creation\n' +
+        '• `social_media_campaign` - Social media campaign\n' +
+        '• `coding_project` - Open-source or internal coding project\n' +
+        '• `others` - Other event type\n\n' +
         'Type the format name (e.g., "workshop")',
         { parse_mode: 'Markdown' }
       );


### PR DESCRIPTION
# Pull Request

## Description
Telegram Markdown (parse_mode: 'Markdown') treats underscores as italics delimiters. In the format selection message, values like moderated_discussion and coding_project were bolded with asterisks. The combination of bold and underscores caused an entity parsing error: “can't parse entities… Can't find end of the entity.” The error came from handleEventWizard() when replying with the “Step 3/6” format list. I updated the Step 3 prompt to render format keys in backticks instead of bold, which avoids underscore parsing issues:

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🧹 Code cleanup/refactoring
- [ ] ⚡ Performance improvement
- [ ] 🔧 Configuration change
- [ ] 🧪 Test addition/improvement

