### PR TITLE
Interactive Onboarding & Broadcasts 16s Aligning Webhook and Bot Comm…

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,75 @@
+name: Bug report
+description: File a bug report to help us improve
+labels: [bug]
+title: "bug: <short description>"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out a bug report!
+        Please search existing issues first to avoid duplicates.
+  - type: input
+    id: summary
+    attributes:
+      label: Summary
+      description: A concise description of the bug
+      placeholder: The bot crashes when I run /create_event
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: What steps lead to the issue?
+      placeholder: |
+        1. Run /create_event
+        2. Enter title "Foo"
+        3. See error
+      render: bash
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: The event creation wizard continues to the date step
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      placeholder: The bot replies with an error message "X"
+    validations:
+      required: true
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Environment
+      options:
+        - Local development (PGlite)
+        - Production (PostgreSQL)
+        - Other / Not sure
+    validations:
+      required: true
+  - type: input
+    id: bot_version
+    attributes:
+      label: Bot version / commit
+      description: Include commit SHA or release tag if possible
+      placeholder: e.g. a1b2c3d or v1.2.0
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs (optional)
+      description: Paste error logs or screenshots
+      render: shell
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: I searched for existing issues
+          required: true
+        - label: I can reproduce this issue consistently
+          required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,54 @@
+name: Feature request
+description: Suggest an idea for this project
+labels: [enhancement]
+title: "feat: <short description>"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature! Please provide as much detail as possible.
+  - type: input
+    id: summary
+    attributes:
+      label: Summary
+      description: A concise description of the feature
+      placeholder: Support interactive onboarding pages with images
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation / Problem
+      description: What problem does this feature solve? Why is it valuable?
+      placeholder: Our contributors want to add richer onboarding content, including images.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe how you think this should be implemented
+      placeholder: |
+        1. Add support for a metadata file per page (YAML)
+        2. Allow optional image attachments via Telegram
+        3. Fallback to HTML-only rendering when images are not provided
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other ways to solve this problem
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Scope
+      options:
+        - label: This is backward compatible
+        - label: Requires database changes
+        - label: Requires documentation updates
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Links, references, screenshots

--- a/.github/ISSUE_TEMPLATE/improvement.yml
+++ b/.github/ISSUE_TEMPLATE/improvement.yml
@@ -1,0 +1,55 @@
+name: Improvement / Docs
+description: Suggest an improvement to existing code or docs
+labels: [improvement]
+title: "improve: <short description>"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for proposing an improvement! Please describe the current behavior and the improvement you want to see.
+  - type: input
+    id: summary
+    attributes:
+      label: Summary
+      description: A concise description of the improvement
+      placeholder: Align broadcast volunteers output with list volunteers format
+    validations:
+      required: true
+  - type: textarea
+    id: current
+    attributes:
+      label: Current behavior
+      description: What is happening today?
+      placeholder: The broadcast uses Markdown and different grouping; list volunteers uses HTML with specific groups.
+    validations:
+      required: true
+  - type: textarea
+    id: desired
+    attributes:
+      label: Desired behavior
+      description: What should it look like after the improvement?
+      placeholder: Use HTML parse mode, match grouping and headings, add tracking period.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Proposed changes
+      description: High-level list of changes you'd like to make
+      placeholder: |
+        1. Switch to HTML parsing
+        2. Use formatHumanDate for tracking period
+        3. Escape HTML for names and handles
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Scope
+      options:
+        - label: Affects user-visible messages
+        - label: Requires tests updates
+        - label: Requires documentation updates
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Links, references, screenshots

--- a/README.md
+++ b/README.md
@@ -374,6 +374,47 @@ We welcome contributions! Here's how to get started:
 - [Database Schema](./src/schema.ts) - Complete schema definitions
 - [API Documentation](./src/db-drizzle.ts) - Database service methods
 
+### 📚 Interactive Onboarding Pages
+
+The `/onboard` (alias: `/onboarding`) command is interactive and file-driven. Pages are simple HTML files that live under:
+
+- `src/onboarding-pages/`
+
+Each file becomes one page in the onboarding flow. The bot automatically discovers and sorts pages by filename, so adding a new page is as easy as adding a new `.html` file.
+
+How it works:
+- The bot loads all `.html` files from `src/onboarding-pages/` and sorts them lexicographically (e.g., `01_*.html`, `02_*.html`, ...).
+- The first `<b>...</b>` block in the file is extracted and used as the page title in the header.
+- The entire file content is rendered with `parse_mode: 'HTML'`.
+- Inline navigation buttons (Prev/Next) let users move between pages.
+
+Add a new page:
+1. Create a new HTML file in `src/onboarding-pages/`.
+2. Use a numeric prefix to control ordering, e.g. `04_guidelines.html`.
+3. Start the file with a bold title so it appears in the header, for example:
+
+   ```html
+   <b>Community Guidelines</b>
+
+   • Be respectful and inclusive
+   • Keep discussions on-topic
+   • No unsolicited DMs
+   ```
+
+Recommended HTML elements:
+- Use basic inline tags only: `<b>`, `<i>`, `<code>`, `<a href="...">`.
+- Use plain text bullets (`•`) and newlines for lists.
+- Avoid advanced/unsupported HTML (images, tables, etc.).
+
+Preview locally:
+- Run the bot (`npm run dev:local`) and send `/onboard` to your dev bot.
+- Use the Prev/Next buttons to navigate and verify formatting.
+
+Initial pages included:
+- `01_resources.html` — Links to website, GitHub, events, contact.
+- `02_admins.html` — Current admins/leads (edit this file to keep it up to date).
+- `03_socials.html` — How to post on socials.
+
 ## 🔒 Security
 
 - Never commit sensitive data (tokens, passwords, database URLs)

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -7,6 +7,7 @@ dotenv.config();
 // Import command handlers
 import { 
   onboardCommand, 
+  handleOnboardCallback,
   myStatusCommand, 
   commitCommand,
   assignTaskCommand,
@@ -28,7 +29,8 @@ import {
   removeAssignmentCommand,
   setStatusCommand,
   resetQuarterCommand,
-  handleResetQuarterWizard
+  handleResetQuarterWizard,
+  removeAdminCommand
 } from './commands/admins';
 
 import {
@@ -36,7 +38,9 @@ import {
   broadcastVolunteersCommand,
   broadcastEventsCommand,
   broadcastTasksCommand,
-  broadcastCustomCommand
+  broadcastCustomCommand,
+  broadcastEventDetailsCommand,
+  handleBroadcastEventDetailsConfirmation
 } from './commands/broadcast';
 
 import { 
@@ -83,7 +87,9 @@ Welcome! I help manage volunteer onboarding, event planning, and admin tasks.
 • \`/my_status\` - Check your volunteer status
 • \`/commit <task_id>\` - Sign up for event tasks
 • \`/list_events\` - View upcoming events
-• \`/event_details <event_id>\` - View detailed event information`;
+• \`/event_details <event_id>\` - View detailed event information
+• \`/create_event\` - Create a new event (interactive)
+• \`/edit_event <event_id>\` - Edit your own event (admins can edit any)`;
 
   // Check if user is admin and add admin commands if they are
   if (telegramHandle) {
@@ -97,6 +103,7 @@ Welcome! I help manage volunteer onboarding, event planning, and admin tasks.
 • \`/list_volunteers\` - View all volunteers
 • \`/add_volunteer\` - Add new volunteer (interactive)
 • \`/remove_volunteer @handle\` - Remove volunteer
+• \`/remove_admin @handle\` - Remove admin access from a handle
 • \`/create_event\` - Create new event (interactive with task selection)
 • \`/edit_event <event_id>\` - Edit an event details/tasks (interactive)
 • \`/remove_event <event_id>\` - Remove an event (admin)
@@ -110,6 +117,7 @@ Welcome! I help manage volunteer onboarding, event planning, and admin tasks.
 • \`/broadcast\` - Show broadcast menu for testing
 • \`/broadcast_volunteers\` - Broadcast volunteer status list
 • \`/broadcast_events\` - Broadcast upcoming events
+• \`/broadcast_event_details <event_id>\` - Broadcast a specific event's details
 • \`/broadcast_tasks\` - Broadcast available tasks
 • \`/broadcast_custom <message>\` - Send custom broadcast message
 • \`/reset_quarter\` - Reset all commit counts to 0 (interactive, admin)`;
@@ -149,6 +157,7 @@ bot.command('help', async (ctx) => {
 
 // Volunteer commands
 bot.command('onboard', onboardCommand);
+bot.command('onboarding', onboardCommand);
 bot.command('my_status', myStatusCommand);
 bot.command('commit', commitCommand);
 
@@ -162,13 +171,14 @@ bot.command('remove_volunteer', requireAdmin, removeVolunteerCommand);
 bot.command('assign_task', requireAdmin, assignTaskCommand);
 bot.command('update_task_status', requireAdmin, updateTaskStatusCommand);
 bot.command('remove_assignment', requireAdmin, removeAssignmentCommand);
+bot.command('remove_admin', requireAdmin, removeAdminCommand);
 bot.command('set_commit_count', requireAdmin, setCommitCountCommand);
 bot.command('set_status', requireAdmin, setStatusCommand);
 bot.command('reset_quarter', requireAdmin, resetQuarterCommand);
 bot.command('monthly_report', requireAdmin, monthlyReportCommand);
 bot.command('volunteer_status_report', requireAdmin, volunteerStatusReportCommand);
-bot.command('create_event', requireAdmin, createEventCommand);
-bot.command('edit_event', requireAdmin, editEventCommand);
+bot.command('create_event', createEventCommand);
+bot.command('edit_event', editEventCommand);
 bot.command('list_events', listEventsCommand);
 bot.command('event_details', eventDetailsCommand);
 bot.command('remove_event', requireAdmin, removeEventCommand);
@@ -177,6 +187,7 @@ bot.command('remove_event', requireAdmin, removeEventCommand);
 bot.command('broadcast', requireAdmin, broadcastCommand);
 bot.command('broadcast_volunteers', requireAdmin, broadcastVolunteersCommand);
 bot.command('broadcast_events', requireAdmin, broadcastEventsCommand);
+bot.command('broadcast_event_details', broadcastEventDetailsCommand);
 bot.command('broadcast_tasks', requireAdmin, broadcastTasksCommand);
 bot.command('broadcast_custom', requireAdmin, broadcastCustomCommand);
 
@@ -195,6 +206,13 @@ bot.on('message:text', async (ctx) => {
   await handleRemoveEventConfirmation(ctx);
   // Handle reset quarter wizard
   await handleResetQuarterWizard(ctx);
+  // Handle broadcast event details confirmation
+  await handleBroadcastEventDetailsConfirmation(ctx);
+});
+
+// Handle onboarding navigation callbacks
+bot.on('callback_query:data', async (ctx) => {
+  await handleOnboardCallback(ctx);
 });
 
 // Periodic maintenance tasks
@@ -238,8 +256,9 @@ const setupBotCommands = async () => {
       { command: 'list_volunteers', description: 'View all volunteers (admin)' },
       { command: 'add_volunteer', description: 'Add new volunteer (interactive, admin)' },
       { command: 'remove_volunteer', description: 'Remove volunteer (admin)' },
-      { command: 'create_event', description: 'Create new event with task selection (admin)' },
-      { command: 'edit_event', description: 'Edit an event details/tasks (admin)' },
+      { command: 'remove_admin', description: 'Remove admin access from a handle (admin)' },
+      { command: 'create_event', description: 'Create new event with task selection' },
+      { command: 'edit_event', description: 'Edit an event details/tasks (own events for non-admins)' },
       { command: 'assign_task', description: 'Assign tasks to volunteers (admin)' },
       { command: 'update_task_status', description: 'Update task status (admin)' },
       { command: 'remove_assignment', description: 'Remove a volunteer from a task (admin)' },
@@ -253,6 +272,7 @@ const setupBotCommands = async () => {
       { command: 'broadcast', description: 'Show broadcast menu (admin)' },
       { command: 'broadcast_volunteers', description: 'Broadcast volunteer status (admin)' },
       { command: 'broadcast_events', description: 'Broadcast upcoming events (admin)' },
+      { command: 'broadcast_event_details', description: 'Broadcast a specific event' },
       { command: 'broadcast_tasks', description: 'Broadcast available tasks (admin)' },
       { command: 'broadcast_custom', description: 'Send custom broadcast message (admin)' },
       { command: 'reset_quarter', description: 'Reset all commit counts to 0 (interactive, admin)' },

--- a/src/onboarding-pages/01_resources.html
+++ b/src/onboarding-pages/01_resources.html
@@ -1,0 +1,10 @@
+<b>Welcome to Women Devs SG</b>
+
+Here are some useful links to get you started:
+
+• 🌐 Website: <a href="https://womendevssg.netlify.app/">womendevssg.netlify.app</a>
+• 💻 GitHub: <a href="https://github.com/Women-Devs-SG">github.com/Women-Devs-SG</a>
+• 🗓️ Events: <a href="https://www.meetup.com/women-devs-sg/">www.meetup.com/women-devs-sg/</a>
+• 📧 Contact: <a href="mailto:www.meetup.com/women-devs-sg/">www.meetup.com/women-devs-sg/</a>
+
+Use the Next button below to continue onboarding.

--- a/src/onboarding-pages/02_admins.html
+++ b/src/onboarding-pages/02_admins.html
@@ -1,0 +1,14 @@
+<b>Who Are Our Admins</b>
+
+These are the admins who help run Women Devs SG. Reach out if you need help:
+
+• 👩‍💼 <b>Co-directors</b>
+  
+  • Saloni (@missabawse)
+  • Toshall (@tooshall)
+  • Victoria Lo (@viclo2606)
+
+• 🛠️ <b>Leads</b>
+
+  • Aishwarya E (@cheesenotmac)
+  • Natasha Ann (@natashaannn)

--- a/src/onboarding-pages/03_socials.html
+++ b/src/onboarding-pages/03_socials.html
@@ -1,0 +1,12 @@
+<b>How To Post On Our Socials</b>
+
+Follow these guidelines when posting on our social channels:
+
+• ✅ Keep it respectful, inclusive, and on-topic
+• 🖼️ Use clear images and include alt text for accessibility
+• 🧵 Thread longer posts for readability
+• 🔗 Add relevant links and tags
+• 🗓️ Promote upcoming events at least 1–2 weeks in advance
+• 📣 Share post-event highlights within 48 hours
+
+If unsure, contact an admin for review before posting.


### PR DESCRIPTION
# PR Title
feat: open up event creation, add broadcast + onboarding UX, and refine formatting/permissions

## Summary
This PR improves event permissions and broadcasting, introduces an interactive file-driven onboarding flow, refines message formatting, and adds repository quality-of-life templates.

- Non-admins can create events; editing is restricted so non-admins can only edit events they created (admins can edit any).
- New broadcast command for event details with confirmation and creator permission support.
- Interactive onboarding with pages discovered dynamically from `src/onboarding-pages/`.
- Volunteer broadcast message updated to mirror the list volunteers format.
- Issue templates added for bugs, features, and improvements.

## Key Changes

- **Event Creation & Editing**
  - Allow non-admins to create events and record `created_by` on creation.
  - Restrict editing for non-admins to events they created; admins can edit any event.
  - Fix `/edit_event` menus to avoid italicizing `add_task` and `remove_task` by using HTML and `<code>` (underscores now render literally).
  - Fix event creation success message to await [formatEventDetails()](cci:1://file:///d:/CascadeProjects/telegram-volunteer-bot/src/utils.ts:89:0-162:2) (removes `[object Promise]`).

- **Task/Event Completion Cascades**
  - On marking a task as complete, increment assigned volunteers’ commitment count by 1 and auto-promote probation/inactive volunteers to active if commitments >= 3.
  - On marking an event as completed, cascade to mark all its tasks complete by calling [updateTaskStatus()](cci:1://file:///d:/CascadeProjects/telegram-volunteer-bot/src/db-drizzle.ts:482:2-506:3) (avoids double counting increments).

- **Broadcasting**
  - New command: `/broadcast_event_details <event_id>`
    - Admins can broadcast any event.
    - Non-admins can broadcast only events they created (checked against `event.created_by`).
    - Adds a YES/CANCEL confirmation flow before sending to the group.
  - `/event_details` now shows a “Broadcast this event” quick action for eligible users (creators or admins).
  - `/broadcast_volunteers` output now mirrors the list volunteers style (HTML, grouped sections, tracking period line).

- **Interactive Onboarding**
  - New directory: [`src/onboarding-pages/`](./src/onboarding-pages/)
    - [[01_resources.html](cci:7://file:///d:/CascadeProjects/telegram-volunteer-bot/src/onboarding-pages/01_resources.html:0:0-0:0)](./src/onboarding-pages/01_resources.html)
    - [[02_admins.html](cci:7://file:///d:/CascadeProjects/telegram-volunteer-bot/src/onboarding-pages/02_admins.html:0:0-0:0)](./src/onboarding-pages/02_admins.html)
    - [[03_socials.html](cci:7://file:///d:/CascadeProjects/telegram-volunteer-bot/src/onboarding-pages/03_socials.html:0:0-0:0)](./src/onboarding-pages/03_socials.html)
  - `/onboard` (alias `/onboarding`) loads [.html](cci:7://file:///d:/CascadeProjects/telegram-volunteer-bot/src/onboarding-pages/02_admins.html:0:0-0:0) pages dynamically (sorted lexicographically), renders with inline Prev/Next buttons via callback queries.
  - Contributors can add pages by dropping new [.html](cci:7://file:///d:/CascadeProjects/telegram-volunteer-bot/src/onboarding-pages/02_admins.html:0:0-0:0) files in `src/onboarding-pages/`.

- **Docs & Templates**
  - README section added to document the onboarding pages workflow and how to contribute new pages.
  - GitHub issue templates added:
    - [[bug_report.yml](cci:7://file:///d:/CascadeProjects/telegram-volunteer-bot/.github/ISSUE_TEMPLATE/bug_report.yml:0:0-0:0)](./.github/ISSUE_TEMPLATE/bug_report.yml)
    - [[feature_request.yml](cci:7://file:///d:/CascadeProjects/telegram-volunteer-bot/.github/ISSUE_TEMPLATE/feature_request.yml:0:0-0:0)](./.github/ISSUE_TEMPLATE/feature_request.yml)
    - [[improvement.yml](cci:7://file:///d:/CascadeProjects/telegram-volunteer-bot/.github/ISSUE_TEMPLATE/improvement.yml:0:0-0:0)](./.github/ISSUE_TEMPLATE/improvement.yml)

## Implementation Notes

- **Files Updated (highlights)**
  - [[src/commands/events.ts](cci:7://file:///d:/CascadeProjects/telegram-volunteer-bot/src/commands/events.ts:0:0-0:0)](./src/commands/events.ts)
    - Open [createEventCommand](cci:1://file:///d:/CascadeProjects/telegram-volunteer-bot/src/commands/events.ts:25:0-56:2) to non-admins; ensure `created_by` is passed to [createEvent](cci:1://file:///d:/CascadeProjects/telegram-volunteer-bot/src/db-drizzle.ts:255:2-286:3).
    - Enforce edit permissions in [editEventCommand](cci:1://file:///d:/CascadeProjects/telegram-volunteer-bot/src/commands/events.ts:58:0-119:2) and in interactive `await_id` flow.
    - Fix underscore rendering by switching to HTML and using `<code>add_task</code>`/`<code>remove_task</code>`.
    - Fix success message to await [formatEventDetails()](cci:1://file:///d:/CascadeProjects/telegram-volunteer-bot/src/utils.ts:89:0-162:2).
    - Add quick action for “Broadcast this event” in [eventDetailsCommand](cci:1://file:///d:/CascadeProjects/telegram-volunteer-bot/src/commands/events.ts:678:0-709:2).

  - [[src/db-drizzle.ts](cci:7://file:///d:/CascadeProjects/telegram-volunteer-bot/src/db-drizzle.ts:0:0-0:0)](./src/db-drizzle.ts)
    - [updateTaskStatus()](cci:1://file:///d:/CascadeProjects/telegram-volunteer-bot/src/db-drizzle.ts:482:2-506:3): on transition to `complete`, increment commitments and conditionally promote.
    - [updateEventStatus()](cci:1://file:///d:/CascadeProjects/telegram-volunteer-bot/src/db-drizzle.ts:311:2-333:3): when set to `completed`, call [updateTaskStatus()](cci:1://file:///d:/CascadeProjects/telegram-volunteer-bot/src/db-drizzle.ts:482:2-506:3) on tasks (no double increment).
    - New helper: [incrementCommitmentsAndMaybePromote()](cci:1://file:///d:/CascadeProjects/telegram-volunteer-bot/src/db-drizzle.ts:335:2-350:3).

  - [[src/commands/admins.ts](cci:7://file:///d:/CascadeProjects/telegram-volunteer-bot/src/commands/admins.ts:0:0-0:0)](./src/commands/admins.ts)
    - [removeAdminCommand](cci:1://file:///d:/CascadeProjects/telegram-volunteer-bot/src/commands/admins.ts:537:0-576:2) for `/remove_admin @handle`.

  - [[src/bot.ts](cci:7://file:///d:/CascadeProjects/telegram-volunteer-bot/src/bot.ts:0:0-0:0)](./src/bot.ts)
    - Open `/create_event` and `/edit_event` to all users (permission checks remain inside handlers).
    - Wire `/broadcast_event_details` without admin middleware (creator permission check is in the command).
    - Add onboarding alias `/onboarding` and wire callback handler for page navigation.
    - Update help text and command auto-complete.

  - [[src/commands/broadcast.ts](cci:7://file:///d:/CascadeProjects/telegram-volunteer-bot/src/commands/broadcast.ts:0:0-0:0)](./src/commands/broadcast.ts)
    - [broadcastEventDetailsCommand](cci:1://file:///d:/CascadeProjects/telegram-volunteer-bot/src/commands/broadcast.ts:18:0-75:2): permission checks, confirmation flow, and HTML rendering via [formatEventDetails()](cci:1://file:///d:/CascadeProjects/telegram-volunteer-bot/src/utils.ts:89:0-162:2).
    - [handleBroadcastEventDetailsConfirmation](cci:1://file:///d:/CascadeProjects/telegram-volunteer-bot/src/commands/broadcast.ts:72:0-115:2): YES/CANCEL flow.
    - [broadcastVolunteersCommand](cci:1://file:///d:/CascadeProjects/telegram-volunteer-bot/src/commands/broadcast.ts:138:0-213:2): rewrite to HTML and mirror list volunteers format.

  - [[src/utils.ts](cci:7://file:///d:/CascadeProjects/telegram-volunteer-bot/src/utils.ts:0:0-0:0)](./src/utils.ts)
    - [formatEventDetails()](cci:1://file:///d:/CascadeProjects/telegram-volunteer-bot/src/utils.ts:89:0-162:2): task section styling and human-friendly dates via [formatHumanDate()](cci:1://file:///d:/CascadeProjects/telegram-volunteer-bot/src/utils.ts:14:0-22:2).

  - [`src/onboarding-pages/`](./src/onboarding-pages/)
    - [[01_resources.html](cci:7://file:///d:/CascadeProjects/telegram-volunteer-bot/src/onboarding-pages/01_resources.html:0:0-0:0)](./src/onboarding-pages/01_resources.html), [[02_admins.html](cci:7://file:///d:/CascadeProjects/telegram-volunteer-bot/src/onboarding-pages/02_admins.html:0:0-0:0)](./src/onboarding-pages/02_admins.html), [[03_socials.html](cci:7://file:///d:/CascadeProjects/telegram-volunteer-bot/src/onboarding-pages/03_socials.html:0:0-0:0)](./src/onboarding-pages/03_socials.html).

  - [[README.md](cci:7://file:///d:/CascadeProjects/telegram-volunteer-bot/README.md:0:0-0:0)](./README.md)
    - “Interactive Onboarding Pages” section with instructions and conventions.

  - `.github/ISSUE_TEMPLATE/`
    - [[bug_report.yml](cci:7://file:///d:/CascadeProjects/telegram-volunteer-bot/.github/ISSUE_TEMPLATE/bug_report.yml:0:0-0:0)](./.github/ISSUE_TEMPLATE/bug_report.yml), [[feature_request.yml](cci:7://file:///d:/CascadeProjects/telegram-volunteer-bot/.github/ISSUE_TEMPLATE/feature_request.yml:0:0-0:0)](./.github/ISSUE_TEMPLATE/feature_request.yml), [[improvement.yml](cci:7://file:///d:/CascadeProjects/telegram-volunteer-bot/.github/ISSUE_TEMPLATE/improvement.yml:0:0-0:0)](./.github/ISSUE_TEMPLATE/improvement.yml)

## Testing Steps

- **Event Creation/Editing**
  1. As a non-admin, run `/create_event` and complete the wizard.
  2. Run `/edit_event <id>` for your event: verify you can edit.
  3. As a non-admin, try editing another user’s event: expect a permission error.
  4. As an admin, verify editing any event works.

- **Broadcast**
  1. As event creator, run `/broadcast_event_details <id>` and confirm with `YES`: verify message in group.
  2. As non-creator non-admin, try broadcasting another user’s event: expect a permission error.
  3. As admin, broadcasting any event should work.

- **Completion Cascades**
  1. Assign volunteers to a task, then mark the task `complete`: verify commitment increments and promotions at threshold.
  2. Mark an event `completed`: verify all tasks are complete and increments happen once (no double count).

- **Onboarding**
  1. Run `/onboard` or `/onboarding`: verify page rendering and navigation.
  2. Add a new file `04_guidelines.html` and re-run: verify it appears as a new page in order.

- **Volunteer Broadcast**
  1. Run `/broadcast_volunteers` (admin): verify HTML output mirrors list volunteers format with tracking period.

## Checklist

- [x] Permissions enforced for create/edit/broadcast flows
- [x] Confirmation before broadcasting to group
- [x] No double counting of commitments on event completion
- [x] Onboarding pages load dynamically and support easy contributions
- [x] Help text and command list updated
- [x] Issue templates added

## Breaking Changes
- None expected. Commands opened to non-admins rely on internal permission checks, maintaining safety.

## Related Issues
- N/A (new features and improvements)