### PR TITLE
feat(admin reset): broadcast pre-reset volunteer list and admin handl…

### DIFF
--- a/api/webhook.ts
+++ b/api/webhook.ts
@@ -12,7 +12,6 @@ import {
   commitCommand,
   assignTaskCommand,
   updateTaskStatusCommand,
-  monthlyReportCommand,
   volunteerStatusReportCommand,
 } from '../src/commands/volunteers';
 
@@ -103,7 +102,6 @@ Welcome! I help manage volunteer onboarding, event planning, and admin tasks.
 • \`/remove_assignment <task_id> @volunteer\` - Remove a volunteer from a task
 • \`/set_commit_count @volunteer <count>\` - Overwrite a volunteer's commit count
 • \`/set_status @volunteer <probation/active/inactive>\` - Update a volunteer's status
-• \`/monthly_report\` - Generate monthly volunteer status report
 • \`/volunteer_status_report\` - View current volunteer status
 • \`/broadcast\` - Show broadcast menu for testing
 • \`/broadcast_volunteers\` - Broadcast volunteer status list
@@ -166,7 +164,6 @@ bot.command('set_commit_count', requireAdmin, setCommitCountCommand);
 bot.command('set_status', requireAdmin, setStatusCommand);
 bot.command('remove_admin', requireAdmin, removeAdminCommand);
 bot.command('reset_quarter', requireAdmin, resetQuarterCommand);
-bot.command('monthly_report', requireAdmin, monthlyReportCommand);
 bot.command('volunteer_status_report', requireAdmin, volunteerStatusReportCommand);
 bot.command('create_event', createEventCommand);
 bot.command('edit_event', editEventCommand);
@@ -232,7 +229,6 @@ const setupBotCommands = async () => {
       { command: 'remove_assignment', description: 'Remove a volunteer from a task (admin)' },
       { command: 'set_commit_count', description: 'Overwrite a volunteer\'s commit count (admin)' },
       { command: 'set_status', description: 'Update a volunteer\'s status (admin)' },
-      { command: 'monthly_report', description: 'Generate monthly volunteer status report (admin)' },
       { command: 'volunteer_status_report', description: 'View current volunteer status (admin)' },
       { command: 'list_events', description: 'View upcoming events with tasks' },
       { command: 'event_details', description: 'View detailed event information' },

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -12,7 +12,6 @@ import {
   commitCommand,
   assignTaskCommand,
   updateTaskStatusCommand,
-  monthlyReportCommand,
   volunteerStatusReportCommand
 } from './commands/volunteers';
 
@@ -55,8 +54,7 @@ import {
   cancelCommand
 } from './commands/events';
 
-import { processMonthlyVolunteerStatus } from './utils';
-import { VolunteerScheduler } from './scheduler';
+// Removed monthly processing utilities and scheduler (no auto scheduling)
 
 // Validate required environment variables
 const BOT_TOKEN = process.env.BOT_TOKEN;
@@ -68,8 +66,7 @@ if (!BOT_TOKEN) {
 // Create bot instance
 const bot = new Bot(BOT_TOKEN);
 
-// Create scheduler instance
-const scheduler = new VolunteerScheduler(bot);
+// Scheduler removed by design; no automatic scheduling
 
 // Error handling
 bot.catch((err) => {
@@ -112,7 +109,6 @@ Welcome! I help manage volunteer onboarding, event planning, and admin tasks.
 • \`/remove_assignment <task_id> @volunteer\` - Remove a volunteer from a task
 • \`/set_commit_count @volunteer <count>\` - Overwrite a volunteer's commit count
 • \`/set_status @volunteer <probation/active/inactive>\` - Update a volunteer's status
-• \`/monthly_report\` - Generate monthly volunteer status report
 • \`/volunteer_status_report\` - View current volunteer status
 • \`/broadcast\` - Show broadcast menu for testing
 • \`/broadcast_volunteers\` - Broadcast volunteer status list
@@ -175,7 +171,6 @@ bot.command('remove_admin', requireAdmin, removeAdminCommand);
 bot.command('set_commit_count', requireAdmin, setCommitCountCommand);
 bot.command('set_status', requireAdmin, setStatusCommand);
 bot.command('reset_quarter', requireAdmin, resetQuarterCommand);
-bot.command('monthly_report', requireAdmin, monthlyReportCommand);
 bot.command('volunteer_status_report', requireAdmin, volunteerStatusReportCommand);
 bot.command('create_event', createEventCommand);
 bot.command('edit_event', editEventCommand);
@@ -233,13 +228,11 @@ setInterval(runMaintenanceTasks, 60 * 60 * 1000);
 // Graceful shutdown
 process.once('SIGINT', () => {
   console.log('🛑 Received SIGINT, shutting down gracefully...');
-  scheduler.stop();
   bot.stop();
 });
 
 process.once('SIGTERM', () => {
   console.log('🛑 Received SIGTERM, shutting down gracefully...');
-  scheduler.stop();
   bot.stop();
 });
 
@@ -264,7 +257,6 @@ const setupBotCommands = async () => {
       { command: 'remove_assignment', description: 'Remove a volunteer from a task (admin)' },
       { command: 'set_commit_count', description: 'Overwrite a volunteer\'s commit count (admin)' },
       { command: 'set_status', description: 'Update a volunteer\'s status (admin)' },
-      { command: 'monthly_report', description: 'Generate monthly volunteer status report (admin)' },
       { command: 'volunteer_status_report', description: 'View current volunteer status (admin)' },
       { command: 'list_events', description: 'View upcoming events with tasks' },
       { command: 'event_details', description: 'View detailed event information' },
@@ -294,9 +286,6 @@ const startBot = async () => {
     
     // Run initial maintenance check
     await runMaintenanceTasks();
-    
-    // Start the monthly scheduler
-    scheduler.start();
     
     // Start polling for updates
     await bot.start();

--- a/src/commands/volunteers.ts
+++ b/src/commands/volunteers.ts
@@ -6,7 +6,6 @@ import {
   formatVolunteerStatus, 
   canVolunteerCommit,
   formatTaskStatus,
-  processMonthlyVolunteerStatus,
   promoteIfEligible
 } from '../utils';
 
@@ -349,33 +348,6 @@ export const updateTaskStatusCommand = async (ctx: CommandContext<Context>) => {
     );
   } else {
     await ctx.reply('❌ Failed to update task status. Please try again.');
-  }
-};
-
-// /monthly_report command (admin only) - generate monthly volunteer status report
-export const monthlyReportCommand = async (ctx: CommandContext<Context>) => {
-  const telegramHandle = ctx.from?.username;
-  
-  if (!telegramHandle) {
-    await ctx.reply('❌ Please set a Telegram username to use this bot.');
-    return;
-  }
-
-  // Check if user is admin
-  const isAdmin = await DrizzleDatabaseService.isAdmin(telegramHandle);
-  if (!isAdmin) {
-    await ctx.reply('❌ This command is only available to administrators.');
-    return;
-  }
-
-  await ctx.reply('📊 Generating monthly volunteer status report...');
-  
-  try {
-    const reportMessage = await processMonthlyVolunteerStatus(ctx.api as any);
-    await ctx.reply(reportMessage, { parse_mode: 'Markdown' });
-  } catch (error) {
-    console.error('Error generating monthly report:', error);
-    await ctx.reply('❌ Failed to generate monthly report. Please try again later.');
   }
 };
 

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -1,91 +1,16 @@
-import { Bot } from 'grammy';
-import { processMonthlyVolunteerStatus } from './utils';
-
-/**
- * Scheduler for automated monthly volunteer status processing
- * This module handles the monthly commitment tracking and status updates
- */
-
+// No-op scheduler: automatic scheduling is intentionally disabled across the codebase
 export class VolunteerScheduler {
-  private bot: Bot;
-  private monthlyInterval: NodeJS.Timeout | null = null;
-
-  constructor(bot: Bot) {
-    this.bot = bot;
+  // start() and stop() exist for compatibility but perform no actions
+  start(): void {
+    console.log('📅 Scheduler is disabled by design; no automatic tasks will run.');
   }
 
-  // Removed admin channel/topic validation helpers (no dedicated admin channel usage)
-
-  /**
-   * Start the monthly scheduler
-   * Runs on the 1st of each month at 9:00 AM
-   * Disabled in development environment
-   */
-  start() {
-    // Don't run scheduler in development environment
-    if (process.env.NODE_ENV === 'development') {
-      console.log('📅 Monthly scheduler disabled in development environment');
-      console.log('💡 Use /monthly_report command to test monthly processing manually');
-      return;
-    }
-
-    // Calculate time until next first of month at 9:00 AM
-    const now = new Date();
-    const nextMonth = new Date(now.getFullYear(), now.getMonth() + 1, 1, 9, 0, 0);
-    const timeUntilNext = nextMonth.getTime() - now.getTime();
-
-    console.log(`📅 Monthly volunteer status scheduler starting...`);
-    console.log(`⏰ Next run scheduled for: ${nextMonth.toISOString()}`);
-
-    // Set initial timeout to first run
-    setTimeout(() => {
-      this.runMonthlyProcess();
-      
-      // Then set up monthly interval (every 30 days)
-      this.monthlyInterval = setInterval(() => {
-        this.runMonthlyProcess();
-      }, 30 * 24 * 60 * 60 * 1000); // 30 days in milliseconds
-      
-    }, timeUntilNext);
+  stop(): void {
+    // nothing to stop
   }
 
-  /**
-   * Stop the monthly scheduler
-   */
-  stop() {
-    if (this.monthlyInterval) {
-      clearInterval(this.monthlyInterval);
-      this.monthlyInterval = null;
-      console.log('📅 Monthly volunteer status scheduler stopped');
-    }
-  }
-
-  /**
-   * Run the monthly volunteer status processing
-   * This will update volunteer statuses based on commitments and send reports
-   */
-  private async runMonthlyProcess() {
-    try {
-      console.log('📊 Running monthly volunteer status processing...');
-      
-      const reportMessage = await processMonthlyVolunteerStatus(this.bot);
-      // No dedicated admin channel; just log the generated report for operators
-      console.log('📊 Monthly report generated (not auto-sent to admin channel):');
-      console.log(reportMessage);
-      
-      console.log('✅ Monthly volunteer status processing completed');
-    } catch (error) {
-      console.error('❌ Error running monthly volunteer status processing:', error);
-      
-      // No admin channel notifications; errors are logged only
-    }
-  }
-
-  /**
-   * Manually trigger the monthly process (for testing or manual runs)
-   */
+  // Manual run is not supported anymore; retained for API compatibility
   async runManual(): Promise<string> {
-    console.log('🔧 Manually triggering monthly volunteer status processing...');
-    return await processMonthlyVolunteerStatus(this.bot);
+    return 'Scheduler disabled; no monthly processing available.';
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -300,76 +300,7 @@ export const promoteIfEligible = async (bot: Bot, volunteerId: number): Promise<
 };
 
 // Mark inactive volunteers based on commitment tracking
-export const processMonthlyVolunteerStatus = async (bot: Bot): Promise<string> => {
-  try {
-    // Update volunteer statuses based on commitments
-    const { updated, inactive } = await DrizzleDatabaseService.updateVolunteerStatusBasedOnCommitments();
-    
-    // Reset commitments for the new month
-    await DrizzleDatabaseService.resetMonthlyCommitments();
-    
-    // Generate status report
-    const report = await DrizzleDatabaseService.getVolunteerStatusReport();
-    
-    let message = `📊 <b>Monthly Volunteer Status Report</b>\n\n`;
-    message += `<b>Status Updates:</b>\n`;
-    message += `• ${updated} volunteers had status changes\n`;
-    message += `• ${inactive} volunteers marked as inactive\n\n`;
-    
-    message += `<b>Current Volunteer Breakdown:</b>\n`;
-    message += `👥 <b>Total Volunteers:</b> ${report.total}\n\n`;
-    
-    if (report.lead.length > 0) {
-      message += `🌟 <b>Lead Volunteers (${report.lead.length}):</b>\n`;
-      report.lead.forEach(v => {
-        const safeName = escapeHtml(v.name);
-        const safeHandle = escapeHtml(v.telegram_handle);
-        message += `• ${safeName} (@${safeHandle})\n`;
-      });
-      message += `\n`;
-    }
-    
-    if (report.active.length > 0) {
-      message += `✅ <b>Active Volunteers (${report.active.length}):</b>\n`;
-      report.active.forEach(v => {
-        const safeName = escapeHtml(v.name);
-        const safeHandle = escapeHtml(v.telegram_handle);
-        message += `• ${safeName} (@${safeHandle}) - ${v.commitments} commitments\n`;
-      });
-      message += `\n`;
-    }
-    
-    if (report.probation.length > 0) {
-      message += `🔄 <b>Probation Volunteers (${report.probation.length}):</b>\n`;
-      report.probation.forEach(v => {
-        const safeName = escapeHtml(v.name);
-        const safeHandle = escapeHtml(v.telegram_handle);
-        message += `• ${safeName} (@${safeHandle}) - ${v.commitments} commitments\n`;
-      });
-      message += `\n`;
-    }
-    
-    if (report.inactive.length > 0) {
-      message += `⚠️ <b>Inactive Volunteers (${report.inactive.length}):</b>\n`;
-      report.inactive.forEach(v => {
-        const safeName = escapeHtml(v.name);
-        const safeHandle = escapeHtml(v.telegram_handle);
-        message += `• ${safeName} (@${safeHandle}) - ${v.commitments} commitments\n`;
-      });
-      message += `\n`;
-    }
-    
-    message += `**Next Steps:**\n`;
-    message += `• Probation volunteers need 3 commitments to become active\n`;
-    message += `• Inactive volunteers should be contacted for reactivation\n`;
-    message += `• Commitment counters have been reset for the new month\n`;
-    
-    return message;
-  } catch (error) {
-    console.error('Error processing monthly volunteer status:', error);
-    return 'Error generating monthly volunteer status report.';
-  }
-};
+// Removed processMonthlyVolunteerStatus and related monthly automation by design
 
 
 // Filter events to show only today and future events


### PR DESCRIPTION
# Pull Request

## Description
- Broadcast on commitment reset:
  - Announces reset to the volunteer group (`VOLUNTEER_GROUP_ID`)
  - Includes the volunteer list and commitment counts prior to the reset
  - Includes the handle of the admin who initiated the reset (if available)
- Remove monthly report generation:
  - Remove `monthlyReportCommand` and its command registration
  - Remove `processMonthlyVolunteerStatus` utility
  - Update help text and `setMyCommands` in both [src/bot.ts](cci:7://file:///d:/CascadeProjects/telegram-volunteer-bot/src/bot.ts:0:0-0:0) and [api/webhook.ts](cci:7://file:///d:/CascadeProjects/telegram-volunteer-bot/api/webhook.ts:0:0-0:0)
- Disable scheduling:
  - Remove scheduler usage from [src/bot.ts](cci:7://file:///d:/CascadeProjects/telegram-volunteer-bot/src/bot.ts:0:0-0:0)
  - Replace [src/scheduler.ts](cci:7://file:///d:/CascadeProjects/telegram-volunteer-bot/src/scheduler.ts:0:0-0:0) with a no-op (no timers, no auto runs)

Note: When `VOLUNTEER_GROUP_ID` is not configured, the bot logs that it skipped the broadcast.

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🧹 Code cleanup/refactoring
- [x] 📚 Documentation update
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ⚡ Performance improvement
- [ ] 🔧 Configuration change
- [ ] 🧪 Test addition/improvement

## Related Issue
Fixes #<issue number>

## Changes Made
- [src/commands/admins.ts](cci:7://file:///d:/CascadeProjects/telegram-volunteer-bot/src/commands/admins.ts:0:0-0:0)
  - Enhanced [handleResetQuarterWizard()](cci:1://file:///d:/CascadeProjects/telegram-volunteer-bot/src/commands/admins.ts:33:0-115:2):
    - Snapshot volunteers pre-reset via [DrizzleDatabaseService.getAllVolunteers()](cci:1://file:///d:/CascadeProjects/telegram-volunteer-bot/src/db-drizzle.ts:224:2-241:3)
    - After [resetQuarterCommitments()](cci:1://file:///d:/CascadeProjects/telegram-volunteer-bot/src/db-drizzle.ts:541:2-575:3), broadcast to group with:
      - New period start date
      - “Reset initiated by @<admin>”
      - Pre-reset volunteer list + commitment counts (sorted)
    - Keep admin confirmation reply
- [src/commands/volunteers.ts](cci:7://file:///d:/CascadeProjects/telegram-volunteer-bot/src/commands/volunteers.ts:0:0-0:0)
  - Removed `monthlyReportCommand`
  - Removed import of `processMonthlyVolunteerStatus`
- [src/utils.ts](cci:7://file:///d:/CascadeProjects/telegram-volunteer-bot/src/utils.ts:0:0-0:0)
  - Removed `processMonthlyVolunteerStatus` and related monthly automation
- [src/bot.ts](cci:7://file:///d:/CascadeProjects/telegram-volunteer-bot/src/bot.ts:0:0-0:0)
  - Removed monthly report imports and command registration
  - Removed scheduler usage and start/stop calls
  - Updated help text and `setMyCommands` (no `/monthly_report`)
- [api/webhook.ts](cci:7://file:///d:/CascadeProjects/telegram-volunteer-bot/api/webhook.ts:0:0-0:0)
  - Parity with [src/bot.ts](cci:7://file:///d:/CascadeProjects/telegram-volunteer-bot/src/bot.ts:0:0-0:0): removed monthly report command; updated help text and `setMyCommands`
- [src/scheduler.ts](cci:7://file:///d:/CascadeProjects/telegram-volunteer-bot/src/scheduler.ts:0:0-0:0)
  - Replaced with no-op implementation; no timers or scheduling

## Testing
- [x] I have run `npm test` and all tests pass
- [x] I have run `npm run lint` and there are no linting errors
- [x] I have tested the bot commands manually in development
- [x] I have verified the database operations work correctly
- [x] I have aligned [api/webhook.ts](cci:7://file:///d:/CascadeProjects/telegram-volunteer-bot/api/webhook.ts:0:0-0:0) with [src/bot.ts](cci:7://file:///d:/CascadeProjects/telegram-volunteer-bot/src/bot.ts:0:0-0:0) for new commands/handlers (Vercel parity)
- [ ] I have run `npm run check:parity` and resolved any mismatches

### Test Commands Run
```bash
npm test
npm run lint
npm run setup:local
npm run dev:local