### PR TITLE
fix(bot): prevent Telegram Markdown parse error and add user-facing error notices

### DIFF
--- a/api/webhook.ts
+++ b/api/webhook.ts
@@ -63,9 +63,21 @@ if (!BOT_TOKEN) {
 // Create bot instance
 const bot = new Bot(BOT_TOKEN);
 
-// Error handling
-bot.catch((err) => {
+// Error handling with user-friendly notification
+bot.catch(async (err) => {
   console.error('Bot error:', err);
+  const ctx = (err as any).ctx as any;
+  if (ctx && typeof ctx.reply === 'function') {
+    try {
+      await ctx.reply(
+        '⚠️ An unexpected error occurred while processing your request. Please try again.\n\n' +
+          'If this keeps happening, please notify an admin or open an issue on our GitHub repo:\n' +
+          'https://github.com/Women-Devs-SG/volunteer-telegram-bot/issues',
+      );
+    } catch (sendErr) {
+      console.error('Failed to send error notification to user:', sendErr);
+    }
+  }
 });
 
 // Help message function (aligned with src/bot.ts)

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -68,9 +68,21 @@ const bot = new Bot(BOT_TOKEN);
 
 // Scheduler removed by design; no automatic scheduling
 
-// Error handling
-bot.catch((err) => {
+// Error handling with user-friendly notification
+bot.catch(async (err) => {
   console.error('Bot error:', err);
+  const ctx = (err as any).ctx as Context | undefined;
+  if (ctx) {
+    try {
+      await ctx.reply(
+        '⚠️ An unexpected error occurred while processing your request. Please try again.\n\n' +
+          'If this keeps happening, please notify an admin or open an issue on our GitHub repo:\n' +
+          'https://github.com/Women-Devs-SG/volunteer-telegram-bot/issues',
+      );
+    } catch (sendErr) {
+      console.error('Failed to send error notification to user:', sendErr);
+    }
+  }
 });
 
 // Help message function

--- a/src/commands/volunteers.ts
+++ b/src/commands/volunteers.ts
@@ -124,7 +124,7 @@ export const myStatusCommand = async (ctx: CommandContext<Context>) => {
   }
 
   const statusMessage = formatVolunteerStatus(volunteer);
-  await ctx.reply(statusMessage, { parse_mode: 'Markdown' });
+  await ctx.reply(statusMessage, { parse_mode: 'HTML' });
 };
 
 // /commit command - volunteer commits to a task
@@ -277,9 +277,9 @@ export const updateTaskStatusCommand = async (ctx: CommandContext<Context>) => {
 
   const statusHelp =
     '❓ Task status options:\n' +
-    '• todo — Task has not been started yet\n' +
-    '• in_progress — Work is currently underway\n' +
-    '• complete — Task has been finished (increments volunteer commitments)\n\n' +
+    '• `todo` — Task has not been started yet\n' +
+    '• `in_progress` — Work is currently underway\n' +
+    '• `complete` — Task has been finished (increments volunteer commitments)\n\n' +
     '✅ Usage: `/update_task_status <task_id> <status>`\n' +
     'Example: `/update_task_status 12 in_progress`\n' +
     'Example: `/update_task_status 12 complete`';


### PR DESCRIPTION
## Title
Fix Telegram Markdown parse error in update_task_status and add user-facing error notifications

## Summary
This PR fixes a Markdown entity parsing issue caused by underscores in the `/update_task_status` help message and adds a global user-facing error message for unexpected failures, instructing users to report issues.

## Changes
- [src/commands/volunteers.ts](cci:7://file:///d:/CascadeProjects/telegram-volunteer-bot/src/commands/volunteers.ts:0:0-0:0)
  - Wrap status keywords in backticks in `statusHelp` within [updateTaskStatusCommand()](cci:1://file:///d:/CascadeProjects/telegram-volunteer-bot/src/commands/volunteers.ts:273:0-351:2) to avoid Markdown underscore parsing issues.
  - Use `parse_mode: 'HTML'` in [myStatusCommand()](cci:1://file:///d:/CascadeProjects/telegram-volunteer-bot/src/commands/volunteers.ts:106:0-127:2) to match the HTML output from [formatVolunteerStatus()](cci:1://file:///d:/CascadeProjects/telegram-volunteer-bot/src/utils.ts:55:0-79:2).
- [src/bot.ts](cci:7://file:///d:/CascadeProjects/telegram-volunteer-bot/src/bot.ts:0:0-0:0)
  - Enhance `bot.catch` to reply with a plain-text error message and link to GitHub issues.
- [api/webhook.ts](cci:7://file:///d:/CascadeProjects/telegram-volunteer-bot/api/webhook.ts:0:0-0:0)
  - Mirror the enhanced `bot.catch` error handling in webhook deployment.

## Motivation
- Prevent 400 “can't parse entities” errors on Telegram when underscores are present.
- Provide a better UX when unexpected errors occur by informing users and guiding them to report issues.

## How to Test
- As an admin:
  - Send `/update_task_status` with no arguments and verify the help text renders correctly with backticked statuses.
  - Send `/update_task_status 1 in_progress` and `/update_task_status 1 complete` (adjust task IDs as needed); ensure responses succeed without parse errors.
- Force an error (e.g., temporarily throwing from a command) and verify:
  - The user receives the plain-text error notice with a link to open a GitHub issue.
  - The server logs still show the underlying error for debugging.

## Screenshots / Logs
- N/A (behavioral change; error no longer reproducible with corrected formatting).

## Checklist
- [x] Fix Markdown parsing for underscores by code-formatting tokens.
- [x] Ensure `parse_mode` matches content type (HTML vs Markdown).
- [x] Add user-facing error message in both local and webhook bot entry points.
- [x] Verified no regressions in other commands using Markdown.
- [x] Updated no DB or schema; safe to deploy.

## Additional Notes
If desired, we can follow up by scanning other Markdown responses for risky characters and standardize on either MarkdownV2 with proper escaping or HTML where appropriate to further harden formatting.

## Related Issues
- Fixes runtime 400 “can't parse entities” errors for `sendMessage` in [updateTaskStatusCommand](cci:1://file:///d:/CascadeProjects/telegram-volunteer-bot/src/commands/volunteers.ts:273:0-351:2).