### PR TITLE
feat: add missing check:parity command, fixed bot command regex

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npx lint-staged
+npm run check:parity && npx lint-staged

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "test:coverage": "vitest run --coverage",
     "db:generate": "drizzle-kit generate",
     "db:introspect": "ts-node scripts/introspect-db.ts",
-    "prepare": "husky"
+    "prepare": "husky",
+    "check:parity": "ts-node scripts/check-command-parity.ts"
   },
   "lint-staged": {
     "*.{js,ts,mts}": "npm run lint"

--- a/scripts/check-command-parity.ts
+++ b/scripts/check-command-parity.ts
@@ -3,11 +3,13 @@ import path from 'path';
 
 function extractCommands(filePath: string): Set<string> {
   const src = fs.readFileSync(filePath, 'utf8');
-  const cmdRegex = /bot\.command\(\s*'([^']+)'/g;
+  const cmdRegex = /^bot\.command\(\s*'([^']+)'/gm;
   const commands = new Set<string>();
   let m: RegExpExecArray | null;
   while ((m = cmdRegex.exec(src)) !== null) {
-    commands.add(m[1]);
+     if (m[1]) {
+      commands.add(m[1]);
+    }
   }
   return commands;
 }

--- a/tests/check-command-parity.test.ts
+++ b/tests/check-command-parity.test.ts
@@ -187,17 +187,6 @@ describe("check-command-parity", () => {
       expect(exitSpy).toHaveBeenCalledWith(0);
     });
 
-    // Current behavior - all bot commands are declared without any nesting
-    // it("does not extract indented bot.command calls", async () => {
-    //   mockBotContent =
-    //     "bot.command('start', handler);\n  bot.command('indented', handler);";
-    //   mockWebhookContent = "bot.command('start', handler);";
-
-    //   const { exitSpy } = await loadScript();
-
-    //   expect(exitSpy).toHaveBeenCalledWith(0);
-    // });
-
     it("ignores bot.command calls with an empty command name", async () => {
       const content = "bot.command('', handler);";
       mockBotContent = content;

--- a/tests/check-command-parity.test.ts
+++ b/tests/check-command-parity.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+let mockBotExists = true;
+let mockWebhookExists = true;
+let mockBotContent = "";
+let mockWebhookContent = "";
+
+vi.mock("fs", () => {
+  const mock = {
+    existsSync: vi.fn((filePath: unknown) => {
+      if (String(filePath).endsWith("bot.ts")) return mockBotExists;
+      if (String(filePath).endsWith("webhook.ts")) return mockWebhookExists;
+      return true;
+    }),
+    readFileSync: vi.fn((filePath: unknown) => {
+      if (String(filePath).endsWith("bot.ts")) return mockBotContent;
+      if (String(filePath).endsWith("webhook.ts")) return mockWebhookContent;
+      return "";
+    }),
+  };
+  return { ...mock, default: mock };
+});
+
+async function loadScript() {
+  const exitSpy = vi
+    .spyOn(process, "exit")
+    .mockImplementation(() => undefined as never);
+  const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  await import("../scripts/check-command-parity");
+  return { exitSpy, consoleSpy, errorSpy };
+}
+
+describe("check-command-parity", () => {
+  beforeEach(() => {
+    mockBotExists = true;
+    mockWebhookExists = true;
+    mockBotContent = "";
+    mockWebhookContent = "";
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("when source files are missing", () => {
+    it("exits with code 2 when both files are missing", async () => {
+      mockBotExists = false;
+      mockWebhookExists = false;
+
+      const { exitSpy, errorSpy } = await loadScript();
+
+      expect(exitSpy).toHaveBeenCalledWith(2);
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Unable to locate"),
+      );
+    });
+
+    it("exits with code 2 when only bot.ts is missing", async () => {
+      mockBotExists = false;
+
+      const { exitSpy, errorSpy } = await loadScript();
+
+      expect(exitSpy).toHaveBeenCalledWith(2);
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Unable to locate"),
+      );
+    });
+
+    it("exits with code 2 when only webhook.ts is missing", async () => {
+      mockWebhookExists = false;
+
+      const { exitSpy, errorSpy } = await loadScript();
+
+      expect(exitSpy).toHaveBeenCalledWith(2);
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Unable to locate"),
+      );
+    });
+  });
+
+  describe("when commands match between both files", () => {
+    it("exits with code 0 and reports parity OK", async () => {
+      const content =
+        "bot.command('start', handler);\nbot.command('help', handler);\nbot.command('list_events', handler);";
+      mockBotContent = content;
+      mockWebhookContent = content;
+
+      const { exitSpy, consoleSpy } = await loadScript();
+
+      expect(exitSpy).toHaveBeenCalledWith(0);
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Command parity OK"),
+      );
+    });
+
+    it("lists all matched commands in the output", async () => {
+      const content =
+        "bot.command('start', handler);\nbot.command('help', handler);";
+      mockBotContent = content;
+      mockWebhookContent = content;
+
+      const { consoleSpy } = await loadScript();
+
+      const output = consoleSpy.mock.calls.flat().join(" ");
+      expect(output).toContain("start");
+      expect(output).toContain("help");
+    });
+  });
+
+  describe("when commands are missing in webhook.ts", () => {
+    it("exits with code 1 and reports which commands are missing", async () => {
+      mockBotContent =
+        "bot.command('start', h);\nbot.command('new_command', h);";
+      mockWebhookContent = "bot.command('start', h);";
+
+      const { exitSpy, consoleSpy } = await loadScript();
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      const output = consoleSpy.mock.calls.flat().join(" ");
+      expect(output).toContain("new_command");
+      expect(output).toContain("MISSING in api/webhook.ts");
+    });
+  });
+
+  describe("when webhook.ts has extra commands not in bot.ts", () => {
+    it("exits with code 1 and reports which commands are extra", async () => {
+      mockBotContent = "bot.command('start', h);";
+      mockWebhookContent =
+        "bot.command('start', h);\nbot.command('ghost_command', h);";
+
+      const { exitSpy, consoleSpy } = await loadScript();
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      const output = consoleSpy.mock.calls.flat().join(" ");
+      expect(output).toContain("ghost_command");
+      expect(output).toContain("NOT in src/bot.ts");
+    });
+  });
+
+  describe("when both files have mismatches in both directions", () => {
+    it("exits with code 1 and reports both missing and extra commands", async () => {
+      mockBotContent = "bot.command('start', h);\nbot.command('bot_only', h);";
+      mockWebhookContent =
+        "bot.command('start', h);\nbot.command('webhook_only', h);";
+
+      const { exitSpy, consoleSpy } = await loadScript();
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      const output = consoleSpy.mock.calls.flat().join(" ");
+      expect(output).toContain("bot_only");
+      expect(output).toContain("MISSING in api/webhook.ts");
+      expect(output).toContain("webhook_only");
+      expect(output).toContain("NOT in src/bot.ts");
+    });
+  });
+
+  describe("command extraction", () => {
+    it("ignores commented-out and non-bot.command lines", async () => {
+      mockBotContent =
+        "bot.command('start', handler);\n// bot.command('commented_out', handler);\nconst x = someOtherBot.command('ignored', handler);";
+      mockWebhookContent = "bot.command('start', handler);";
+
+      const { exitSpy } = await loadScript();
+
+      expect(exitSpy).toHaveBeenCalledWith(0);
+    });
+
+    it("deduplicates repeated commands in the same file", async () => {
+      const content =
+        "bot.command('start', handler);\nbot.command('start', anotherHandler);";
+      mockBotContent = content;
+      mockWebhookContent = content;
+
+      const { exitSpy } = await loadScript();
+
+      expect(exitSpy).toHaveBeenCalledWith(0);
+    });
+
+    it("treats two empty files as parity OK", async () => {
+      mockBotContent = "";
+      mockWebhookContent = "";
+
+      const { exitSpy } = await loadScript();
+
+      expect(exitSpy).toHaveBeenCalledWith(0);
+    });
+
+    // Current behavior - all bot commands are declared without any nesting
+    // it("does not extract indented bot.command calls", async () => {
+    //   mockBotContent =
+    //     "bot.command('start', handler);\n  bot.command('indented', handler);";
+    //   mockWebhookContent = "bot.command('start', handler);";
+
+    //   const { exitSpy } = await loadScript();
+
+    //   expect(exitSpy).toHaveBeenCalledWith(0);
+    // });
+
+    it("ignores bot.command calls with an empty command name", async () => {
+      const content = "bot.command('', handler);";
+      mockBotContent = content;
+      mockWebhookContent = content;
+
+      const { exitSpy } = await loadScript();
+
+      expect(exitSpy).toHaveBeenCalledWith(0);
+    });
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description
<!-- Provide a brief description of what this PR does -->
Adds missing `npm run check:parity command` listed in the template with unit tests and fixes the regex for command parity comparison in case of commands that are commented out

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [x] 🧹 Code cleanup/refactoring
- [ ] ⚡ Performance improvement
- [ ] 🔧 Configuration change
- [x] 🧪 Test addition/improvement

## Related Issue
<!-- Link to the issue this PR addresses -->
Fixes #63 

## Changes Made
<!-- List the specific changes made in this PR -->
- Added `npm run check:parity` based on existing check-command-parity.ts script
- Updated regex to extract and compare commands (e.g. commented out commands)
- Added unit tests
- Added `npm run check:parity` to pre-commit hook to reduce the need for manual checks (as listed in the template)

## Testing
<!-- Describe the tests you ran to verify your changes -->
- [x] I have run `npm run test:local` and all tests pass
- [x] I have run `npm run lint` and there are no linting errors
- [x] I have tested the bot commands manually in development
- [x] I have verified the database operations work correctly
- [x] I have aligned `api/webhook.ts` with `src/bot.ts` for new commands/handlers (Vercel parity)
- [x] I have run `npm run check:parity` and resolved any mismatches

### Test Commands Run
```bash
# List the specific commands you ran to test
npm run check:parity
npm run test:local
npm run lint
npm run setup:local
```

## Database Changes
<!-- If this PR includes database schema changes -->
- [x] No database changes
- [ ] Database migration included
- [ ] Sample data updated
- [ ] Migration tested locally

## Bot Commands Affected
<!-- List any bot commands that are new, modified, or removed -->
- [x] No command changes
- [ ] New commands: 
- [ ] Modified commands: 
- [ ] Removed commands: 

## Checklist
<!-- Mark completed items with an "x" -->
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
 - [ ] Help text and command auto-complete updated in both `src/bot.ts` and `api/webhook.ts`

## Screenshots/Demo
<!-- If applicable, add screenshots or demo GIFs to help explain your changes -->
<img width="676" height="159" alt="image" src="https://github.com/user-attachments/assets/cf6cddd0-0161-485c-b192-88486910dcab" />

Unable to commit if there are missing commands
<img width="458" height="173" alt="image" src="https://github.com/user-attachments/assets/cf29debf-9ce9-4f27-87d0-602be7c13b0e" />



## Additional Notes
<!-- Add any additional notes, concerns, or context for reviewers -->

## Reviewer Guidelines
<!-- For reviewers -->
### Testing Steps
1. Pull the branch locally
2. Run `npm install` to ensure dependencies are up to date
3. Run `npm run setup:local` to set up the local database
4. Run `npm run test:local` to verify all tests pass
5. Run `npm run check:parity` if there are changes to bot commands
6. Test the bot functionality manually if applicable

### Review Focus Areas
- [x] Code quality and adherence to project standards
- [x] Test coverage for new functionality
- [ ] Documentation updates
- [ ] Database migration safety (if applicable)
- [ ] Bot command functionality and user experience

## Related Issues
Closes #102 
